### PR TITLE
fix: corrected typo 'context' to 'content' in AI response parsing

### DIFF
--- a/ai-ticket-assistant/utils/ai.js
+++ b/ai-ticket-assistant/utils/ai.js
@@ -49,7 +49,7 @@ Ticket information:
 - Title: ${ticket.title}
 - Description: ${ticket.description}`);
 
-  const raw = response.output[0].context;
+  const raw = response.output[0].content;
 
   try {
     const match = raw.match(/```json\s*([\s\S]*?)\s*```/i);


### PR DESCRIPTION
This PR fixes a critical bug where the response from the AI was not parsed correctly
due to a typo ('context' instead of 'content'). This change ensures the AI's JSON
response is correctly used to enhance ticket processing.

Let me know if anything needs tweaking. Thanks!
